### PR TITLE
fix: fix sendSUDT with locktype

### DIFF
--- a/src/builders/simple-sudt-builder.ts
+++ b/src/builders/simple-sudt-builder.ts
@@ -9,12 +9,13 @@ import {
   SUDT,
 } from '../models';
 import PWCore, { cellOccupiedBytes } from '..';
-import { SUDTCollector } from '../collectors/sudt-collector';
+import { SUDTCollector, CollectorOptions } from '../collectors/';
 
 export interface SimpleSUDTBuilderOptions extends BuilderOption {
   autoCalculateCapacity?: boolean;
   minimumOutputCellCapacity?: Amount;
   maximumOutputCellCapacity?: Amount;
+  defaultCollectorOptions?: CollectorOptions;
 }
 
 export class SimpleSUDTBuilder extends Builder {
@@ -117,7 +118,7 @@ export class SimpleSUDTBuilder extends Builder {
     const unspentSUDTCells = await this.collector.collectSUDT(
       this.sudt,
       PWCore.provider.address,
-      { neededAmount: this.amount }
+      { ...this.options.defaultCollectorOptions, neededAmount: this.amount }
     );
 
     // build a tx including sender and receiver sudt cell only
@@ -179,7 +180,7 @@ export class SimpleSUDTBuilder extends Builder {
 
     const unspentCKBCells = await this.collector.collect(
       PWCore.provider.address,
-      { neededAmount }
+      { ...this.options.defaultCollectorOptions, neededAmount }
     );
 
     if (!unspentCKBCells || unspentCKBCells.length === 0) {

--- a/src/builders/simple-sudt-builder.ts
+++ b/src/builders/simple-sudt-builder.ts
@@ -8,7 +8,7 @@ import {
   Transaction,
   SUDT,
 } from '../models';
-import PWCore, { cellOccupiedBytes } from '..';
+import PWCore, { cellOccupiedBytes, LockTypeOmniPw } from '..';
 import { SUDTCollector, CollectorOptions } from '../collectors/';
 
 export interface SimpleSUDTBuilderOptions extends BuilderOption {
@@ -16,6 +16,7 @@ export interface SimpleSUDTBuilderOptions extends BuilderOption {
   minimumOutputCellCapacity?: Amount;
   maximumOutputCellCapacity?: Amount;
   defaultCollectorOptions?: CollectorOptions;
+  changeCellLockType?: LockTypeOmniPw;
 }
 
 export class SimpleSUDTBuilder extends Builder {
@@ -202,7 +203,7 @@ export class SimpleSUDTBuilder extends Builder {
     if (inputSum.gt(neededAmount)) {
       const changeCell = new Cell(
         inputSum.sub(ckbAmount),
-        PWCore.provider.address.toLockScript()
+        PWCore.provider.address.toLockScript(this.options.changeCellLockType)
       );
       this.outputCells.push(changeCell);
 

--- a/src/builders/simple-sudt-builder.ts
+++ b/src/builders/simple-sudt-builder.ts
@@ -184,7 +184,7 @@ export class SimpleSUDTBuilder extends Builder {
     );
 
     if (!unspentCKBCells || unspentCKBCells.length === 0) {
-      throw new Error('no avaiable CKB');
+      throw new Error('no available CKB');
     }
 
     for (const ckbCell of unspentCKBCells) {

--- a/src/models/script.ts
+++ b/src/models/script.ts
@@ -1,5 +1,11 @@
 import { HashType, CKBModel } from '../interfaces';
-import { Address, AddressPrefix, AddressType, getDefaultPrefix, LockType } from './address';
+import {
+  Address,
+  AddressPrefix,
+  AddressType,
+  getDefaultPrefix,
+  LockType,
+} from './address';
 import { generateCkbAddressString } from '../utils';
 import { validators, transformers, normalizers } from '../ckb-js-toolkit';
 import { SerializeScript } from '../ckb-lumos/core';

--- a/src/models/script.ts
+++ b/src/models/script.ts
@@ -1,5 +1,5 @@
 import { HashType, CKBModel } from '../interfaces';
-import { Address, AddressType, getDefaultPrefix, LockType } from './address';
+import { Address, AddressPrefix, AddressType, getDefaultPrefix, LockType } from './address';
 import { generateCkbAddressString } from '../utils';
 import { validators, transformers, normalizers } from '../ckb-js-toolkit';
 import { SerializeScript } from '../ckb-lumos/core';
@@ -103,7 +103,7 @@ export class Script implements CKBModel {
   }
 
   toAddress(
-    prefix = getDefaultPrefix(),
+    prefix: AddressPrefix = getDefaultPrefix(),
     addressVersion = NervosAddressVersion.latest
   ): Address {
     return new Address(


### PR DESCRIPTION
## Context

These fixes to pw-core were required to get sendSUDT working in use case of sending dCKB from Layer 1 to Layer 2 deposit account. The script is working and is using this version of pw-core. The script can be found here: https://github.com/nervosnetwork/layer2-evm-documentation/blob/master/code-examples/l1-to-l2-sudt-transfer/index.mjs

Here's log from successful transfer of dCKB from L1 to Godwoken:
```
node index.mjs
Transferring from CKB address: ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqw3wvcn550clsmmean4dx6x827cnkqcgncz88uxh
To Ethereum address on Layer 2: 0xD173313A51f8fc37BcF67569b463abd89d81844f
Deposit to Layer 2 address on Layer 1: 
ckt1qnxzkns56l07k8nj7acg4skh7cm2ug3tqqa6c67vlnu0fhltm8r3gj2qy3h3dr6pqepfm3jp4hfnsxjykhh0v8nh2s2z7k2wnpn8rft45yqqqqqsqqqqqvqqqqqfjqqqqzu3u2hxanhpdr2vkcjlcxts3k87emrdxfwyndy9m9aadz7wjz57y6gqqqqpqqqqqqcqqqqqxyqqqqqs2u0ezpelms7daaxa4kttggzd6vxkx40nmk56d4lup7sryeqgmgqngqqqqpy5qfr0z685zpjznhryrtwn8qdyfd0w7c08w4q59av5axrxwxjht5tnxya9r78ux770vatfk336hkyasxzy7q9rqgqqqqqqcqeeaud2
SUDT balance: 638
Transferring to Layer 2
calculateWitnessArgs() cannot be used when witnessArgs was specified in the constructor.
calculateWitnessArgs() cannot be used when witnessArgs was specified in the constructor.
calculateWitnessArgs() cannot be used when witnessArgs was specified in the constructor.
calculateWitnessArgs() cannot be used when witnessArgs was specified in the constructor.
Layer 1 transaction hash: 0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c
tx 0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c is pending, waited for 0 seconds
tx 0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c is pending, waited for 10 seconds
tx 0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c is pending, waited for 20 seconds
tx 0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c is committed, waited for 30 seconds
Getting SUDT ID on Layer 2...
SUDT ID on Layer 2: 11408
Deploying SUDT proxy contract to check balance on Layer 2...
Getting balance on Layer 2...
Waiting 120s before checking Layer 2 balance to give operator time to process SUDT deposit.
{ tokenBalanceOnLayer2: '101480000000' }
```

Example successful tx: https://explorer.nervos.org/aggron/transaction/0x2852be6ef5ef7a8e24487f2efebe384f3d32df806c5d11af5aeec3e1e6498f1c

## Other changes

Without changeCell customization option the SUDT was transferred from L1 to L2, but change cell was OmniLock instead of PwLock (https://explorer.nervos.org/aggron/transaction/0x77df7d8568375629423955a73102a7cac6934d9da746dbaf7121b5e0bc9df5a0). I expect when sending SUDT from Pw Lock to some address the CKB to stay on Pw Lock address, not changed to OmniLock (I don't think sendSUDT is supposed to be migration script).

Also adds type annotation for prefix because if building manually as part of node_modules (when using Git commit ref as npm dependency) there's an error:
```
➜  pw-core git:(master) ✗ yarn build
yarn run v1.22.17
$ run-s clean && run-p build:*
$ trash build test
$ tsc -p tsconfig.module.json && cp -r src/types/* build/module/
$ tsc -p tsconfig.json && cp -r src/types/* build/main/
src/models/script.ts:106:5 - error TS2742: The inferred type of 'prefix' cannot be named without a reference to '@lay2/pw-core/node_modules/@nervosnetwork/ckb-sdk-utils/lib/address'. This is likely not portable. A type annotation is necessary.

106     prefix = getDefaultPrefix(),
        ~~~~~~


Found 1 error.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "build:module" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```